### PR TITLE
Complete Callback

### DIFF
--- a/modules/gateways/callback/bitpay.php
+++ b/modules/gateways/callback/bitpay.php
@@ -24,7 +24,7 @@ if (is_string($response))
 }
 
 
-if ($response['status']=="confirmed") {
+if ($response['status']=="confirmed" || $response['status']=="complete") {
 	$invoiceid = $response['posData'];
 	$invoiceid = checkCbInvoiceID($invoiceid,$GATEWAY["name"]); # Checks invoice ID is a valid invoice number or ends processing
 	


### PR DESCRIPTION
Fixed an issue where transactions under the "low" speed setting would not call back, due to the transaction being classified as "complete" and not "confirmed"
