### PR TITLE
Updating callback to reflect changes in bitpay policies

### DIFF
--- a/modules/gateways/callback/bitpay.php
+++ b/modules/gateways/callback/bitpay.php
@@ -64,11 +64,8 @@ if (true === is_string($response) || true === empty($response)) {
     // Checks transaction number isn't already in the database and ends processing if it does
     checkCbTransID($transid);
 
-    // Successful
-    $fee = 0;
-
-    // left blank, this will auto-fill as the full balance
-    $amount = '';
+    $amount = $response['price'];
+    $fee = bcmul($response['price'], "0.01",4);
 
     switch ($response['status']) {
         case 'paid':


### PR DESCRIPTION
Bitpay changed its minimum fee to 1% for most proper businesses. So we are updating the fee manually to 1% because IPN does not report fees, bad bitpay IPN :(. Plus sometimes people overpay or underpay but that is never reflected in invoice (in the first case transaction is recorded as received with same amount as invoice however we received more, in the second case invoice is never marked paid and the transaction is not recorded)