### PR TITLE
Move production API endpoint to non-www address as the www seems broken

### DIFF
--- a/modules/gateways/bitpaycheckout/bitpaycheckout_ipn.php
+++ b/modules/gateways/bitpaycheckout/bitpaycheckout_ipn.php
@@ -53,7 +53,7 @@ $endpoint = $gatewayParams['bitpay_checkout_endpoint'];
 if($endpoint == "Test"):
     $url_check = 'https://test.bitpay.com/invoices/'.$order_invoice;
 else:
-    $url_check = 'https://www.bitpay.com/invoices/'.$order_invoice;
+    $url_check = 'https://bitpay.com/invoices/'.$order_invoice;
 endif;
 $invoiceStatus = json_decode(checkInvoiceStatus($url_check));
 


### PR DESCRIPTION
The currently configured production endpoint returns empty responses. The non-www variant seems to be the correct one.