### PR TITLE
Remove the hard setting of invoices as paid as WHMCS already has logic for that

### DIFF
--- a/modules/gateways/bitpaycheckout/bitpaycheckout_ipn.php
+++ b/modules/gateways/bitpaycheckout/bitpaycheckout_ipn.php
@@ -79,17 +79,6 @@ if($btn_id):
 switch ($event['name']) {
      #complete, update invoice table to Paid
      case 'invoice_completed':
-     
-        $table = "tblinvoices";
-        $update = array("status" => 'Paid','datepaid' => date("Y-m-d H:i:s"));
-        $where = array("id" => $orderid, "paymentmethod" => "bitpaycheckout");
-        try{
-        update_query($table, $update, $where);
-        }
-        catch (Exception $e ){
-         file_put_contents($file,$e,FILE_APPEND);
-      }
-
         #update the bitpay_invoice table
         $table = "_bitpay_checkout_transactions";
         $update = array("transaction_status" => $event['name']);


### PR DESCRIPTION
The setting of the invoice as Paid in the IPN code is now obsolete that several lines below the addInvoicePayment is used. WHMCS has internal logic to mark the invoice as paid if the full payment is logged.

Apart from obsolete, this code actually breaks WHMCS hooks as the are not executed if the invoices is force marked as Paid in the DB.